### PR TITLE
fix: queenside castling FEN parse overwrites a8 with the piece on h8

### DIFF
--- a/src/JSChessEngine/FEN.utils.ts
+++ b/src/JSChessEngine/FEN.utils.ts
@@ -86,7 +86,7 @@ export const prepareCastlingByFEN = (
     if (!!preparedState[0][0].figure) {
       // Ладья
       preparedState[0][0].figure = {
-        ...preparedState[0][preparedState.length - 1].figure!,
+        ...preparedState[0][0].figure!,
         touched: false,
       };
   

--- a/src/JSChessEngine/__tests__/FEN.utils.test.ts
+++ b/src/JSChessEngine/__tests__/FEN.utils.test.ts
@@ -12,6 +12,9 @@ const FEN_WITH_BEATED_FIELD =
   'rnbqkbnr/pppppppp/8/8/6p1/8/PPPPPP1P/RNBQKBNR b KQkq g4 0 1';
 const FEN_WITHOUT_LONG_CASTLINGS =
   '1rbqkb1r/pppppp1p/2n2np1/8/8/2N2PP1/PPPPP2P/1RBQKBNR w Kk - 3 4';
+// Чёрный король и ладья a8 на месте (флаг рокировки `q` присутствует),
+// но на h8 стоит чужая фигура — белый конь (как после Nxh8).
+const FEN_CAPTURE_ON_H8 = 'r3k2N/8/8/8/8/8/8/4K3 b q - 0 1';
 
 describe('Тесты на FENtoGameState', () => {
   it('FENtoGameState вернет правильный стейт для воссоздани начальной позиции', () => {
@@ -48,6 +51,19 @@ describe('Тесты на FENtoGameState', () => {
 
     expect(gameState.currentColor).toBe('black');
     expect(gameState.boardState[5][6].beated).toBeTruthy();
+  });
+
+  it('FENtoGameState не затирает ладью a8 фигурой с h8 при флаге рокировки q', () => {
+    const gameState = FENtoGameState(FEN_CAPTURE_ON_H8);
+
+    // a8 должна остаться чёрной ладьёй, а не превратиться в копию коня с h8
+    expect(gameState.boardState[0][0].figure?.type).toBe('rook');
+    expect(gameState.boardState[0][0].figure?.color).toBe('black');
+    expect(gameState.boardState[0][0].figure?.touched).toBeFalsy();
+
+    // h8 остаётся нетронутой
+    expect(gameState.boardState[0][7].figure?.type).toBe('knight');
+    expect(gameState.boardState[0][7].figure?.color).toBe('white');
   });
 });
 


### PR DESCRIPTION
## Problem

In `prepareCastlingByFEN`, the black queenside (`q`) branch clones the figure from **h8** instead of **a8** when resetting `touched: false`:

```ts
if (castlingNotation.includes('q')) {
  if (!!preparedState[0][0].figure) {
    preparedState[0][0].figure = {
      ...preparedState[0][preparedState.length - 1].figure!, // ← reads h8, not a8
      touched: false,
    };
```

The symmetric `K` / `Q` / `k` branches all read and write the *same* square. Only the `q` branch reads a different one.

As a result, **any FEN carrying the `q` castling flag overwrites the a8 piece with whatever sits on h8.** The bug is latent while h8 holds the black rook (cloning rook → rook is a no-op aside from `touched`), so it stays hidden in the common case. It surfaces the first time a different piece lands on h8 — e.g. parsing a position reached after `Nxh8`: the a8 rook silently turns into a copy of the white knight.

## Fix

Read the source figure from `preparedState[0][0]` (a8) to match the other three branches. One-line change.

## Test

Added a regression test to `FEN.utils.test.ts` that parses a position with a foreign piece on h8 while the `q` flag is set, and asserts a8 keeps its black rook (and h8 is untouched). Verified it fails before the fix (`a8` parses as `knight`) and passes after.